### PR TITLE
Add wild battle False Swipe toggle

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -735,6 +735,8 @@ struct BattleStruct
     u8 throwingPokeBall:1;
     u8 ballSpriteIds[2];    // item gfx, window gfx
     u8 moveInfoSpriteId; // move info, window gfx
+    u8 falseSwipeSpriteId; // false swipe toggle window gfx
+    u8 falseSwipeActive:1;
     u8 appearedInBattle; // Bitfield to track which Pokemon appeared in battle. Used for Burmy's form change
     u8 skyDropTargets[MAX_BATTLERS_COUNT]; // For Sky Drop, to account for if multiple Pokemon use Sky Drop in a double battle.
     // When using a move which hits multiple opponents which is then bounced by a target, we need to make sure, the move hits both opponents, the one with bounce, and the one without.

--- a/include/battle_interface.h
+++ b/include/battle_interface.h
@@ -138,5 +138,8 @@ void UpdateAbilityPopup(u8 battlerId);
 void CategoryIcons_LoadSpritesGfx(void);
 void TryToAddMoveInfoWindow(void);
 void TryToHideMoveInfoWindow(void);
+void TryToAddFalseSwipeWindow(void);
+void TryToHideFalseSwipeWindow(void);
+void PrintOnFalseSwipeWindow(bool32 active);
 
 #endif // GUARD_BATTLE_INTERFACE_H

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -288,6 +288,8 @@
 #define B_LAST_USED_BALL            TRUE       // If TRUE, the "last used ball" feature from Gen 7 will be implemented
 #define B_LAST_USED_BALL_BUTTON     R_BUTTON   // If last used ball is implemented, this button (or button combo) will trigger throwing the last used ball.
 #define B_LAST_USED_BALL_CYCLE      TRUE       // If TRUE, then holding B_LAST_USED_BALL_BUTTON while pressing the D-Pad cycles through the balls
+#define B_FALSE_SWIPE_TOGGLE        TRUE       // If TRUE, allows toggling False Swipe effect during wild battles
+#define B_FALSE_SWIPE_BUTTON        R_BUTTON   // Button used to toggle the False Swipe effect
 #define B_CATCH_SWAP_INTO_PARTY     GEN_LATEST // In Gen 7+, the option to swap the caught wild mon to the party will appear, allowing you to send a different mon to the box.
 #define B_CATCH_SWAP_CHECK_HMS      TRUE       // If TRUE, the catch swap feature above will prevent returning mons to the box if they know HMs.
 

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -677,6 +677,7 @@ void HandleInputChooseMove(u32 battler)
     if (JOY_NEW(A_BUTTON) && !gBattleStruct->descriptionSubmenu)
     {
         TryToHideMoveInfoWindow();
+        TryToHideFalseSwipeWindow();
         PlaySE(SE_SELECT);
 
         moveTarget = GetBattlerMoveTargetType(battler, moveInfo->moves[gMoveSelectionCursor[battler]]);
@@ -785,6 +786,7 @@ void HandleInputChooseMove(u32 battler)
             HideGimmickTriggerSprite();
             PlayerBufferExecCompleted(battler);
             TryToHideMoveInfoWindow();
+            TryToHideFalseSwipeWindow();
         }
     }
     else if (JOY_NEW(DPAD_LEFT) && !gBattleStruct->zmove.viewing)
@@ -894,6 +896,15 @@ void HandleInputChooseMove(u32 battler)
     {
         gBattleStruct->descriptionSubmenu = TRUE;
         TryMoveSelectionDisplayMoveDescription(battler);
+    }
+    else if (JOY_NEW(B_FALSE_SWIPE_BUTTON))
+    {
+        if (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER))
+        {
+            gBattleStruct->falseSwipeActive ^= 1;
+            PlaySE(SE_SELECT);
+            PrintOnFalseSwipeWindow(gBattleStruct->falseSwipeActive);
+        }
     }
     else if (JOY_NEW(START_BUTTON))
     {
@@ -2157,6 +2168,7 @@ void PlayerHandleChooseMove(u32 battler)
         InitMoveSelectionsVarsAndStrings(battler);
         gBattleStruct->gimmick.playerSelect = FALSE;
         TryToAddMoveInfoWindow();
+        TryToAddFalseSwipeWindow();
 
         AssignUsableZMoves(battler, moveInfo->moves);
         gBattleStruct->zmove.viable = (gBattleStruct->zmove.possibleZMoves[battler] & (1u << gMoveSelectionCursor[battler])) != 0;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2223,7 +2223,8 @@ static void Cmd_adjustdamage(void)
 
         gPotentialItemEffectBattler = battlerDef;
 
-        if (moveEffect == EFFECT_FALSE_SWIPE)
+        if (moveEffect == EFFECT_FALSE_SWIPE
+            || (gBattleStruct->falseSwipeActive && GetBattlerSide(gBattlerAttacker) == B_SIDE_PLAYER && !(gBattleTypeFlags & BATTLE_TYPE_TRAINER)))
         {
             enduredHit = TRUE;
         }


### PR DESCRIPTION
## Summary
- allow toggling a False Swipe effect in wild battles
- add R-button UI indicator and configuration
- show/hide the indicator with move info UI
- change indicator text to "Don't KO" and highlight when active
- fix linkage for PrintOnFalseSwipeWindow
- fix sprite callbacks and text colors

## Testing
- `make -j4` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fe70b908832e8c978f1fa8f051cf