### PR TITLE
Improve crafting quantity UI

### DIFF
--- a/include/craft_menu_ui.h
+++ b/include/craft_menu_ui.h
@@ -25,5 +25,8 @@ void CraftMenuUI_EndSwapMode(void);
 bool8 CraftMenuUI_InSwapMode(void);
 void CraftMenuUI_RedrawInfo(void);
 void CraftMenuUI_PrintInfo(const u8 *text, u8 x, u8 y);
+u8 CraftMenuUI_AddQuantityWindow(void);
+void CraftMenuUI_PrintQuantity(u16 quantity);
+void CraftMenuUI_RemoveQuantityWindow(void);
 
 #endif // GUARD_CRAFT_MENU_UI_H

--- a/src/craft_menu.c
+++ b/src/craft_menu.c
@@ -270,7 +270,8 @@ static bool8 HandleSlotActionInput(void)
         return TRUE;
     case SLOT_ACTION_ADJUST_QTY:
         Action_AdjustQuantity();
-        break;
+        gMenuCallback = NULL;
+        return FALSE;
     case SLOT_ACTION_SWAP_SLOT:
         Action_StartSwapSlot();
         break;
@@ -333,6 +334,7 @@ static void Task_AdjustQuantity(u8 taskId)
         sOldQty = gCraftSlots[CraftMenuUI_GetCursorPos()].quantity;
         sMaxQty = sOldQty + CountTotalItemQuantityInBag(sItemId);
         gTasks[taskId].data[1] = sOldQty;
+        gMenuCallback = NULL;
         CopyItemNameHandlePlural(sItemId, gStringVar1, 2);
         StringExpandPlaceholders(gStringVar4, sText_CraftPlaceHowManyVar1);
         CraftMenuUI_PrintInfo(gStringVar4, 2, 7);

--- a/src/craft_menu.c
+++ b/src/craft_menu.c
@@ -39,6 +39,8 @@ static void Task_AdjustQuantity(u8 taskId);
 static void CraftMenu_ReshowAfterBagMenu(void);
 void CB2_ReturnToCraftMenu(void);
 
+static const u8 sText_CraftPlaceHowManyVar1[] = _("Place how many {STR_VAR_1}?");
+
 void StartCraftMenu(void)
 {
     PlayerFreeze();
@@ -331,14 +333,17 @@ static void Task_AdjustQuantity(u8 taskId)
         sOldQty = gCraftSlots[CraftMenuUI_GetCursorPos()].quantity;
         sMaxQty = sOldQty + CountTotalItemQuantityInBag(sItemId);
         gTasks[taskId].data[1] = sOldQty;
+        CopyItemNameHandlePlural(sItemId, gStringVar1, 2);
+        StringExpandPlaceholders(gStringVar4, sText_CraftPlaceHowManyVar1);
+        CraftMenuUI_PrintInfo(gStringVar4, 2, 7);
+        CraftMenuUI_AddQuantityWindow();
+        CraftMenuUI_PrintQuantity(sOldQty);
         gTasks[taskId].data[0] = 1;
         break;
     case 1:
         if (AdjustQuantityAccordingToDPadInput(&gTasks[taskId].data[1], sMaxQty))
         {
-            ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[1], STR_CONV_MODE_LEFT_ALIGN, 3);
-            StringExpandPlaceholders(gStringVar4, gText_xVar1);
-            CraftMenuUI_PrintInfo(gStringVar4, 200, 7);
+            CraftMenuUI_PrintQuantity(gTasks[taskId].data[1]);
         }
 
         if (JOY_NEW(A_BUTTON))
@@ -358,6 +363,7 @@ static void Task_AdjustQuantity(u8 taskId)
         }
         break;
     case 2:
+        CraftMenuUI_RemoveQuantityWindow();
         CraftMenuUI_RedrawInfo();
         gMenuCallback = HandleCraftMenuInput;
         DestroyTask(taskId);

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -42,6 +42,7 @@ enum
     WINDOW_CRAFT_INFO,
     WINDOW_CRAFT_YESNO,
     WINDOW_CRAFT_ACTIONS,
+    WINDOW_CRAFT_QUANTITY,
     NUM_CRAFT_WINDOWS
 };
 
@@ -52,6 +53,7 @@ EWRAM_DATA static u8 sWorkbenchSpriteIds[CRAFT_SLOT_COUNT];
 EWRAM_DATA static u8 sCraftCursorPos = 0;
 EWRAM_DATA static u8 sCraftSlotSpriteIds[CRAFT_SLOT_COUNT];
 EWRAM_DATA static u8 sActionMenuWindowId;
+EWRAM_DATA static u8 sQuantityWindowId;
 EWRAM_DATA static bool8 sInSwapMode = FALSE;
 
 static const u8 sText_CraftingUi_AButton[] = _("{A_BUTTON}");
@@ -123,6 +125,15 @@ static const struct WindowTemplate sCraftWindowTemplates[NUM_CRAFT_WINDOWS] =
         .height = 11,
         .paletteNum = 15,
         .baseBlock = 340,
+    },
+    [WINDOW_CRAFT_QUANTITY] = {
+        .bg = 0,
+        .tilemapLeft = 24,
+        .tilemapTop = 17,
+        .width = 5,
+        .height = 2,
+        .paletteNum = 15,
+        .baseBlock = 410,
     }
 };
 
@@ -489,6 +500,44 @@ void CraftMenuUI_ClearPackUpMessage(void)
         sCraftInfoWindowId = AddWindow(&sCraftWindowTemplates[WINDOW_CRAFT_INFO]);
         ShowInfoWindow();
         UpdateCraftInfoWindow();
+    }
+}
+
+static void ShowQuantityWindow(void)
+{
+    DrawStdFrameWithCustomTileAndPalette(sQuantityWindowId, TRUE, 0x214, 14);
+    FillWindowPixelBuffer(sQuantityWindowId, PIXEL_FILL(1));
+    CopyWindowToVram(sQuantityWindowId, COPYWIN_FULL);
+}
+
+u8 CraftMenuUI_AddQuantityWindow(void)
+{
+    if (sQuantityWindowId == WINDOW_NONE)
+    {
+        sQuantityWindowId = AddWindow(&sCraftWindowTemplates[WINDOW_CRAFT_QUANTITY]);
+        ShowQuantityWindow();
+    }
+    return sQuantityWindowId;
+}
+
+void CraftMenuUI_PrintQuantity(u16 quantity)
+{
+    if (sQuantityWindowId != WINDOW_NONE)
+    {
+        ConvertIntToDecimalStringN(gStringVar1, quantity, STR_CONV_MODE_LEADING_ZEROS, 3);
+        StringExpandPlaceholders(gStringVar4, gText_xVar1);
+        AddTextPrinterParameterized(sQuantityWindowId, FONT_NORMAL, gStringVar4,
+                                   GetStringCenterAlignXOffset(FONT_NORMAL, gStringVar4, 0x28), 2, 0, 0);
+    }
+}
+
+void CraftMenuUI_RemoveQuantityWindow(void)
+{
+    if (sQuantityWindowId != WINDOW_NONE)
+    {
+        ClearStdWindowAndFrameToTransparent(sQuantityWindowId, TRUE);
+        RemoveWindow(sQuantityWindowId);
+        sQuantityWindowId = WINDOW_NONE;
     }
 }
 

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -130,7 +130,8 @@ static const struct WindowTemplate sCraftWindowTemplates[NUM_CRAFT_WINDOWS] =
     [WINDOW_CRAFT_QUANTITY] = {
         .bg = 0,
         .tilemapLeft = 24,
-        .tilemapTop = 17,
+        // Positioned above the info window so the two do not overlap
+        .tilemapTop = 13,
         .width = 5,
         .height = 2,
         .paletteNum = 15,

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -324,6 +324,7 @@ void CraftMenuUI_Init(void)
     }
     sCraftCursorPos = 0;
     sActionMenuWindowId = WINDOW_NONE;
+    sQuantityWindowId = WINDOW_NONE;
     sInSwapMode = FALSE;
 
     LoadCraftWindows();

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -13,6 +13,7 @@
 #include "sound.h"
 #include "strings.h"
 #include "string_util.h"
+#include "international_string_util.h"
 #include "item_icon.h"
 #include "item_menu.h"
 #include "craft_menu.h"

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -129,9 +129,8 @@ static const struct WindowTemplate sCraftWindowTemplates[NUM_CRAFT_WINDOWS] =
     },
     [WINDOW_CRAFT_QUANTITY] = {
         .bg = 0,
-        .tilemapLeft = 24,
-        // Positioned above the info window so the two do not overlap
-        .tilemapTop = 13,
+        .tilemapLeft = 23,
+        .tilemapTop = 11,
         .width = 5,
         .height = 2,
         .paletteNum = 15,


### PR DESCRIPTION
## Summary
- show a small quantity window when adjusting crafting slot amounts
- display "Place how many" prompt in the info window

## Testing
- `make -j4` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f86247e3c832eb64fb5c8674ac462