### PR TITLE
Refactor craft slots to use 2D array directly

### DIFF
--- a/include/craft_logic.h
+++ b/include/craft_logic.h
@@ -7,6 +7,9 @@
 #define CRAFT_COLS 3
 #define CRAFT_SLOT_COUNT (CRAFT_ROWS * CRAFT_COLS)
 
+#define CRAFT_SLOT_ROW(slot) ((slot) / CRAFT_COLS)
+#define CRAFT_SLOT_COL(slot) ((slot) % CRAFT_COLS)
+
 extern struct ItemSlot gCraftSlots[CRAFT_ROWS][CRAFT_COLS];
 extern u8 gCraftActiveSlot;
 

--- a/include/craft_logic.h
+++ b/include/craft_logic.h
@@ -3,9 +3,11 @@
 
 #include "item.h"
 
-#define CRAFT_SLOT_COUNT 9
+#define CRAFT_ROWS 3
+#define CRAFT_COLS 3
+#define CRAFT_SLOT_COUNT (CRAFT_ROWS * CRAFT_COLS)
 
-extern struct ItemSlot gCraftSlots[CRAFT_SLOT_COUNT];
+extern struct ItemSlot gCraftSlots[CRAFT_ROWS][CRAFT_COLS];
 extern u8 gCraftActiveSlot;
 
 void CraftLogic_InitSlots(void);

--- a/src/craft_debug.c
+++ b/src/craft_debug.c
@@ -148,12 +148,12 @@ static void PrintSlots(u8 windowId)
         StringAppend(lineBuffer, numBuffer);
         StringAppend(lineBuffer, sText_ColonSpace);
 
-        if (gCraftSlots[i].itemId != ITEM_NONE)
+        if (gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId != ITEM_NONE)
         {
-            CopyItemName(gCraftSlots[i].itemId, itemName);
+            CopyItemName(gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId, itemName);
             StringAppend(lineBuffer, itemName);
 
-            ConvertIntToDecimalStringN(gStringVar1, gCraftSlots[i].quantity, STR_CONV_MODE_LEFT_ALIGN, 3);
+            ConvertIntToDecimalStringN(gStringVar1, gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].quantity, STR_CONV_MODE_LEFT_ALIGN, 3);
             StringExpandPlaceholders(qtyBuffer, gText_xVar1);
             StringAppend(lineBuffer, qtyBuffer);
         }

--- a/src/craft_debug.c
+++ b/src/craft_debug.c
@@ -131,38 +131,41 @@ void CB2_CraftDebugMenu(void)
 
 static void PrintSlots(u8 windowId)
 {
-    u8 i;
+    int row, col, index;
 
     FillWindowPixelBuffer(windowId, PIXEL_FILL(1));
-
-    for (i = 0; i < CRAFT_SLOT_COUNT; i++)
+    index = 0;
+    for (row = 0; row < CRAFT_ROWS; row++)
     {
-        u8 lineBuffer[64];
-        u8 qtyBuffer[16];
-        u8 itemName[32];
-        u8 numBuffer[4];
-        u8 y = i * 12;
-
-        StringCopy(lineBuffer, sText_SlotLabel);
-        ConvertIntToDecimalStringN(numBuffer, i + 1, STR_CONV_MODE_LEFT_ALIGN, 1);
-        StringAppend(lineBuffer, numBuffer);
-        StringAppend(lineBuffer, sText_ColonSpace);
-
-        if (gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId != ITEM_NONE)
+        for (col = 0; col < CRAFT_COLS; col++, index++)
         {
-            CopyItemName(gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId, itemName);
-            StringAppend(lineBuffer, itemName);
+            u8 lineBuffer[64];
+            u8 qtyBuffer[16];
+            u8 itemName[32];
+            u8 numBuffer[4];
+            u8 y = index * 12;
 
-            ConvertIntToDecimalStringN(gStringVar1, gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].quantity, STR_CONV_MODE_LEFT_ALIGN, 3);
-            StringExpandPlaceholders(qtyBuffer, gText_xVar1);
-            StringAppend(lineBuffer, qtyBuffer);
-        }
-        else
-        {
-            StringAppend(lineBuffer, sText_None);
-        }
+            StringCopy(lineBuffer, sText_SlotLabel);
+            ConvertIntToDecimalStringN(numBuffer, index + 1, STR_CONV_MODE_LEFT_ALIGN, 1);
+            StringAppend(lineBuffer, numBuffer);
+            StringAppend(lineBuffer, sText_ColonSpace);
 
-        AddTextPrinterParameterized3(windowId, FONT_SMALL, 1, y, sDebugTextColor, 0, lineBuffer);
+            if (gCraftSlots[row][col].itemId != ITEM_NONE)
+            {
+                CopyItemName(gCraftSlots[row][col].itemId, itemName);
+                StringAppend(lineBuffer, itemName);
+
+                ConvertIntToDecimalStringN(gStringVar1, gCraftSlots[row][col].quantity, STR_CONV_MODE_LEFT_ALIGN, 3);
+                StringExpandPlaceholders(qtyBuffer, gText_xVar1);
+                StringAppend(lineBuffer, qtyBuffer);
+            }
+            else
+            {
+                StringAppend(lineBuffer, sText_None);
+            }
+
+            AddTextPrinterParameterized3(windowId, FONT_SMALL, 1, y, sDebugTextColor, 0, lineBuffer);
+        }
     }
 
     CopyWindowToVram(windowId, COPYWIN_FULL);

--- a/src/craft_logic.c
+++ b/src/craft_logic.c
@@ -23,8 +23,8 @@ void CraftLogic_SetSlot(u8 slot, u16 itemId, u16 quantity)
     if (slot >= CRAFT_SLOT_COUNT)
         return;
 
-    gCraftSlots[slot / CRAFT_COLS][slot % CRAFT_COLS].itemId = itemId;
-    gCraftSlots[slot / CRAFT_COLS][slot % CRAFT_COLS].quantity = quantity;
+    gCraftSlots[CRAFT_SLOT_ROW(slot)][CRAFT_SLOT_COL(slot)].itemId = itemId;
+    gCraftSlots[CRAFT_SLOT_ROW(slot)][CRAFT_SLOT_COL(slot)].quantity = quantity;
 }
 
 void CraftLogic_SwapSlots(u8 slotA, u8 slotB)
@@ -32,7 +32,7 @@ void CraftLogic_SwapSlots(u8 slotA, u8 slotB)
     if (slotA >= CRAFT_SLOT_COUNT || slotB >= CRAFT_SLOT_COUNT || slotA == slotB)
         return;
 
-    struct ItemSlot temp = gCraftSlots[slotA / CRAFT_COLS][slotA % CRAFT_COLS];
-    gCraftSlots[slotA / CRAFT_COLS][slotA % CRAFT_COLS] = gCraftSlots[slotB / CRAFT_COLS][slotB % CRAFT_COLS];
-    gCraftSlots[slotB / CRAFT_COLS][slotB % CRAFT_COLS] = temp;
+    struct ItemSlot temp = gCraftSlots[CRAFT_SLOT_ROW(slotA)][CRAFT_SLOT_COL(slotA)];
+    gCraftSlots[CRAFT_SLOT_ROW(slotA)][CRAFT_SLOT_COL(slotA)] = gCraftSlots[CRAFT_SLOT_ROW(slotB)][CRAFT_SLOT_COL(slotB)];
+    gCraftSlots[CRAFT_SLOT_ROW(slotB)][CRAFT_SLOT_COL(slotB)] = temp;
 }

--- a/src/craft_logic.c
+++ b/src/craft_logic.c
@@ -2,16 +2,19 @@
 #include "constants/items.h"
 #include "craft_logic.h"
 
-EWRAM_DATA struct ItemSlot gCraftSlots[CRAFT_SLOT_COUNT];
+EWRAM_DATA struct ItemSlot gCraftSlots[CRAFT_ROWS][CRAFT_COLS];
 EWRAM_DATA u8 gCraftActiveSlot = 0;
 
 void CraftLogic_InitSlots(void)
 {
-    int i;
-    for (i = 0; i < CRAFT_SLOT_COUNT; i++)
+    int row, col;
+    for (row = 0; row < CRAFT_ROWS; row++)
     {
-        gCraftSlots[i].itemId = ITEM_NONE;
-        gCraftSlots[i].quantity = 0;
+        for (col = 0; col < CRAFT_COLS; col++)
+        {
+            gCraftSlots[row][col].itemId = ITEM_NONE;
+            gCraftSlots[row][col].quantity = 0;
+        }
     }
 }
 
@@ -20,8 +23,8 @@ void CraftLogic_SetSlot(u8 slot, u16 itemId, u16 quantity)
     if (slot >= CRAFT_SLOT_COUNT)
         return;
 
-    gCraftSlots[slot].itemId = itemId;
-    gCraftSlots[slot].quantity = quantity;
+    gCraftSlots[slot / CRAFT_COLS][slot % CRAFT_COLS].itemId = itemId;
+    gCraftSlots[slot / CRAFT_COLS][slot % CRAFT_COLS].quantity = quantity;
 }
 
 void CraftLogic_SwapSlots(u8 slotA, u8 slotB)
@@ -29,7 +32,7 @@ void CraftLogic_SwapSlots(u8 slotA, u8 slotB)
     if (slotA >= CRAFT_SLOT_COUNT || slotB >= CRAFT_SLOT_COUNT || slotA == slotB)
         return;
 
-    struct ItemSlot temp = gCraftSlots[slotA];
-    gCraftSlots[slotA] = gCraftSlots[slotB];
-    gCraftSlots[slotB] = temp;
+    struct ItemSlot temp = gCraftSlots[slotA / CRAFT_COLS][slotA % CRAFT_COLS];
+    gCraftSlots[slotA / CRAFT_COLS][slotA % CRAFT_COLS] = gCraftSlots[slotB / CRAFT_COLS][slotB % CRAFT_COLS];
+    gCraftSlots[slotB / CRAFT_COLS][slotB % CRAFT_COLS] = temp;
 }

--- a/src/craft_menu.c
+++ b/src/craft_menu.c
@@ -143,16 +143,20 @@ static bool8 HandleCraftMenuInput(void)
     if (JOY_NEW(A_BUTTON))
     {
         PlaySE(SE_SELECT);
-        if (gCraftSlots[CraftMenuUI_GetCursorPos() / CRAFT_COLS][CraftMenuUI_GetCursorPos() % CRAFT_COLS].itemId != ITEM_NONE)
         {
-            CraftMenuUI_ShowActionMenu();
-            gMenuCallback = HandleSlotActionInput;
-            return FALSE;
-        }
-        else
-        {
-            OpenBagFromCraftMenu();
-            return TRUE;
+            int row = CraftMenuUI_GetCursorPos() / CRAFT_COLS;
+            int col = CraftMenuUI_GetCursorPos() % CRAFT_COLS;
+            if (gCraftSlots[row][col].itemId != ITEM_NONE)
+            {
+                CraftMenuUI_ShowActionMenu();
+                gMenuCallback = HandleSlotActionInput;
+                return FALSE;
+            }
+            else
+            {
+                OpenBagFromCraftMenu();
+                return TRUE;
+            }
         }
     }
 
@@ -329,8 +333,12 @@ static void Task_AdjustQuantity(u8 taskId)
     switch (gTasks[taskId].data[0])
     {
     case 0:
-        sItemId = gCraftSlots[CraftMenuUI_GetCursorPos() / CRAFT_COLS][CraftMenuUI_GetCursorPos() % CRAFT_COLS].itemId;
-        sOldQty = gCraftSlots[CraftMenuUI_GetCursorPos() / CRAFT_COLS][CraftMenuUI_GetCursorPos() % CRAFT_COLS].quantity;
+        {
+            int row = CraftMenuUI_GetCursorPos() / CRAFT_COLS;
+            int col = CraftMenuUI_GetCursorPos() % CRAFT_COLS;
+            sItemId = gCraftSlots[row][col].itemId;
+            sOldQty = gCraftSlots[row][col].quantity;
+        }
         sMaxQty = sOldQty + CountTotalItemQuantityInBag(sItemId);
         gTasks[taskId].data[1] = sOldQty;
         gMenuCallback = NULL;
@@ -350,11 +358,13 @@ static void Task_AdjustQuantity(u8 taskId)
         if (JOY_NEW(A_BUTTON))
         {
             u16 newQty = gTasks[taskId].data[1];
+            int row = CraftMenuUI_GetCursorPos() / CRAFT_COLS;
+            int col = CraftMenuUI_GetCursorPos() % CRAFT_COLS;
             if (newQty > sOldQty)
                 RemoveBagItem(sItemId, newQty - sOldQty);
             else if (newQty < sOldQty)
                 AddBagItem(sItemId, sOldQty - newQty);
-            gCraftSlots[CraftMenuUI_GetCursorPos() / CRAFT_COLS][CraftMenuUI_GetCursorPos() % CRAFT_COLS].quantity = newQty;
+            gCraftSlots[row][col].quantity = newQty;
             CraftMenuUI_DrawIcons();
             gTasks[taskId].data[0] = 2;
         }

--- a/src/craft_menu.c
+++ b/src/craft_menu.c
@@ -144,8 +144,8 @@ static bool8 HandleCraftMenuInput(void)
     {
         PlaySE(SE_SELECT);
         {
-            int row = CraftMenuUI_GetCursorPos() / CRAFT_COLS;
-            int col = CraftMenuUI_GetCursorPos() % CRAFT_COLS;
+            int row = CRAFT_SLOT_ROW(CraftMenuUI_GetCursorPos());
+            int col = CRAFT_SLOT_COL(CraftMenuUI_GetCursorPos());
             if (gCraftSlots[row][col].itemId != ITEM_NONE)
             {
                 CraftMenuUI_ShowActionMenu();
@@ -244,7 +244,7 @@ static void Action_SwapItem(void)
 static void Action_RemoveItem(void)
 {
     u8 slot = CraftMenuUI_GetCursorPos();
-    struct ItemSlot *s = &gCraftSlots[slot / CRAFT_COLS][slot % CRAFT_COLS];
+    struct ItemSlot *s = &gCraftSlots[CRAFT_SLOT_ROW(slot)][CRAFT_SLOT_COL(slot)];
     AddBagItem(s->itemId, s->quantity);
     s->itemId = ITEM_NONE;
     s->quantity = 0;
@@ -334,8 +334,8 @@ static void Task_AdjustQuantity(u8 taskId)
     {
     case 0:
         {
-            int row = CraftMenuUI_GetCursorPos() / CRAFT_COLS;
-            int col = CraftMenuUI_GetCursorPos() % CRAFT_COLS;
+            int row = CRAFT_SLOT_ROW(CraftMenuUI_GetCursorPos());
+            int col = CRAFT_SLOT_COL(CraftMenuUI_GetCursorPos());
             sItemId = gCraftSlots[row][col].itemId;
             sOldQty = gCraftSlots[row][col].quantity;
         }
@@ -358,8 +358,8 @@ static void Task_AdjustQuantity(u8 taskId)
         if (JOY_NEW(A_BUTTON))
         {
             u16 newQty = gTasks[taskId].data[1];
-            int row = CraftMenuUI_GetCursorPos() / CRAFT_COLS;
-            int col = CraftMenuUI_GetCursorPos() % CRAFT_COLS;
+            int row = CRAFT_SLOT_ROW(CraftMenuUI_GetCursorPos());
+            int col = CRAFT_SLOT_COL(CraftMenuUI_GetCursorPos());
             if (newQty > sOldQty)
                 RemoveBagItem(sItemId, newQty - sOldQty);
             else if (newQty < sOldQty)

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -232,20 +232,23 @@ static void UpdateCraftInfoWindow(void)
 
 static void UpdateItemInfoWindow(void)
 {
-    if (gCraftSlots[sCraftCursorPos / CRAFT_COLS][sCraftCursorPos % CRAFT_COLS].itemId != ITEM_NONE)
+    int row = sCraftCursorPos / CRAFT_COLS;
+    int col = sCraftCursorPos % CRAFT_COLS;
+
+    if (gCraftSlots[row][col].itemId != ITEM_NONE)
     {
         FillWindowPixelBuffer(sCraftItemInfoWindowId, PIXEL_FILL(1));
         PutWindowTilemap(sCraftItemInfoWindowId);
         DrawStdFrameWithCustomTileAndPalette(sCraftItemInfoWindowId, TRUE, 0x214, 14);
 
         u8 name[ITEM_NAME_LENGTH];
-        CopyItemName(gCraftSlots[sCraftCursorPos / CRAFT_COLS][sCraftCursorPos % CRAFT_COLS].itemId, name);
+        CopyItemName(gCraftSlots[row][col].itemId, name);
         u32 width = WindowWidthPx(sCraftItemInfoWindowId) - 16;
         u8 fontId = GetFontIdToFit(name, FONT_NORMAL, 0, width);
         BreakStringAutomatic(name, width, 0, fontId, HIDE_SCROLL_PROMPT);
         AddTextPrinterParameterized4(sCraftItemInfoWindowId, fontId, 2, 1, 0, 0, sInputTextColor, 0, name);
         //AddTextPrinterParameterized3(sCraftItemInfoWindowId, FONT_NARROWER, 2, 1, sInputTextColor, 0, name);
-        ConvertIntToDecimalStringN(gStringVar1, gCraftSlots[sCraftCursorPos / CRAFT_COLS][sCraftCursorPos % CRAFT_COLS].quantity, STR_CONV_MODE_LEFT_ALIGN, 3);
+        ConvertIntToDecimalStringN(gStringVar1, gCraftSlots[row][col].quantity, STR_CONV_MODE_LEFT_ALIGN, 3);
         StringExpandPlaceholders(gStringVar4, gText_xVar1);
         AddTextPrinterParameterized3(sCraftItemInfoWindowId, FONT_NORMAL, 2, 45, sInputTextColor, 0, gStringVar4);
         CopyWindowToVram(sCraftItemInfoWindowId, COPYWIN_FULL);
@@ -318,44 +321,47 @@ static void DestroyCraftIconSprite(u8 slot)
 
 void CraftMenuUI_DrawIcons(void)
 {
-    int i;
+    int row, col, index, i;
     u8 oldSpriteIds[CRAFT_SLOT_COUNT];
     u16 oldTags[CRAFT_SLOT_COUNT];
 
-    for (i = 0; i < CRAFT_SLOT_COUNT; i++)
+    for (row = 0, index = 0; row < CRAFT_ROWS; row++)
     {
-        oldSpriteIds[i] = SPRITE_NONE;
-        if (gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId != sCraftSlotItemIds[i])
+        for (col = 0; col < CRAFT_COLS; col++, index++)
         {
-            bool8 oldFlip = sCraftSlotTagFlip[i];
-            u16 newTag = GetCraftIconTag(i, !oldFlip);
-            u8 spriteId = SPRITE_NONE;
-
-            if (gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId != ITEM_NONE)
+            oldSpriteIds[index] = SPRITE_NONE;
+            if (gCraftSlots[row][col].itemId != sCraftSlotItemIds[index])
             {
-                spriteId = AddItemIconSprite(newTag, newTag, gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId);
-                if (spriteId != MAX_SPRITES)
-                {
-                    gSprites[spriteId].x = sWorkbenchSlotPositions[i].x + 79;
-                    gSprites[spriteId].y = sWorkbenchSlotPositions[i].y + 28;
-                    gSprites[spriteId].oam.priority = 0;
-                }
-                else
-                {
-                    spriteId = SPRITE_NONE;
-                }
-            }
+                bool8 oldFlip = sCraftSlotTagFlip[index];
+                u16 newTag = GetCraftIconTag(index, !oldFlip);
+                u8 spriteId = SPRITE_NONE;
 
-            if (sCraftSlotSpriteIds[i] != SPRITE_NONE)
-            {
-                gSprites[sCraftSlotSpriteIds[i]].invisible = TRUE;
-                oldSpriteIds[i] = sCraftSlotSpriteIds[i];
-                oldTags[i] = GetCraftIconTag(i, oldFlip);
-            }
+                if (gCraftSlots[row][col].itemId != ITEM_NONE)
+                {
+                    spriteId = AddItemIconSprite(newTag, newTag, gCraftSlots[row][col].itemId);
+                    if (spriteId != MAX_SPRITES)
+                    {
+                        gSprites[spriteId].x = sWorkbenchSlotPositions[index].x + 79;
+                        gSprites[spriteId].y = sWorkbenchSlotPositions[index].y + 28;
+                        gSprites[spriteId].oam.priority = 0;
+                    }
+                    else
+                    {
+                        spriteId = SPRITE_NONE;
+                    }
+                }
 
-            sCraftSlotSpriteIds[i] = spriteId;
-            sCraftSlotItemIds[i] = gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId;
-            sCraftSlotTagFlip[i] = !oldFlip;
+                if (sCraftSlotSpriteIds[index] != SPRITE_NONE)
+                {
+                    gSprites[sCraftSlotSpriteIds[index]].invisible = TRUE;
+                    oldSpriteIds[index] = sCraftSlotSpriteIds[index];
+                    oldTags[index] = GetCraftIconTag(index, oldFlip);
+                }
+
+                sCraftSlotSpriteIds[index] = spriteId;
+                sCraftSlotItemIds[index] = gCraftSlots[row][col].itemId;
+                sCraftSlotTagFlip[index] = !oldFlip;
+            }
         }
     }
 

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -232,20 +232,20 @@ static void UpdateCraftInfoWindow(void)
 
 static void UpdateItemInfoWindow(void)
 {
-    if (gCraftSlots[sCraftCursorPos].itemId != ITEM_NONE)
+    if (gCraftSlots[sCraftCursorPos / CRAFT_COLS][sCraftCursorPos % CRAFT_COLS].itemId != ITEM_NONE)
     {
         FillWindowPixelBuffer(sCraftItemInfoWindowId, PIXEL_FILL(1));
         PutWindowTilemap(sCraftItemInfoWindowId);
         DrawStdFrameWithCustomTileAndPalette(sCraftItemInfoWindowId, TRUE, 0x214, 14);
 
         u8 name[ITEM_NAME_LENGTH];
-        CopyItemName(gCraftSlots[sCraftCursorPos].itemId, name);
+        CopyItemName(gCraftSlots[sCraftCursorPos / CRAFT_COLS][sCraftCursorPos % CRAFT_COLS].itemId, name);
         u32 width = WindowWidthPx(sCraftItemInfoWindowId) - 16;
         u8 fontId = GetFontIdToFit(name, FONT_NORMAL, 0, width);
         BreakStringAutomatic(name, width, 0, fontId, HIDE_SCROLL_PROMPT);
         AddTextPrinterParameterized4(sCraftItemInfoWindowId, fontId, 2, 1, 0, 0, sInputTextColor, 0, name);
         //AddTextPrinterParameterized3(sCraftItemInfoWindowId, FONT_NARROWER, 2, 1, sInputTextColor, 0, name);
-        ConvertIntToDecimalStringN(gStringVar1, gCraftSlots[sCraftCursorPos].quantity, STR_CONV_MODE_LEFT_ALIGN, 3);
+        ConvertIntToDecimalStringN(gStringVar1, gCraftSlots[sCraftCursorPos / CRAFT_COLS][sCraftCursorPos % CRAFT_COLS].quantity, STR_CONV_MODE_LEFT_ALIGN, 3);
         StringExpandPlaceholders(gStringVar4, gText_xVar1);
         AddTextPrinterParameterized3(sCraftItemInfoWindowId, FONT_NORMAL, 2, 45, sInputTextColor, 0, gStringVar4);
         CopyWindowToVram(sCraftItemInfoWindowId, COPYWIN_FULL);
@@ -325,15 +325,15 @@ void CraftMenuUI_DrawIcons(void)
     for (i = 0; i < CRAFT_SLOT_COUNT; i++)
     {
         oldSpriteIds[i] = SPRITE_NONE;
-        if (gCraftSlots[i].itemId != sCraftSlotItemIds[i])
+        if (gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId != sCraftSlotItemIds[i])
         {
             bool8 oldFlip = sCraftSlotTagFlip[i];
             u16 newTag = GetCraftIconTag(i, !oldFlip);
             u8 spriteId = SPRITE_NONE;
 
-            if (gCraftSlots[i].itemId != ITEM_NONE)
+            if (gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId != ITEM_NONE)
             {
-                spriteId = AddItemIconSprite(newTag, newTag, gCraftSlots[i].itemId);
+                spriteId = AddItemIconSprite(newTag, newTag, gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId);
                 if (spriteId != MAX_SPRITES)
                 {
                     gSprites[spriteId].x = sWorkbenchSlotPositions[i].x + 79;
@@ -354,7 +354,7 @@ void CraftMenuUI_DrawIcons(void)
             }
 
             sCraftSlotSpriteIds[i] = spriteId;
-            sCraftSlotItemIds[i] = gCraftSlots[i].itemId;
+            sCraftSlotItemIds[i] = gCraftSlots[i / CRAFT_COLS][i % CRAFT_COLS].itemId;
             sCraftSlotTagFlip[i] = !oldFlip;
         }
     }

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -269,11 +269,11 @@ static void CreateWorkbenchSprite(void)
 
     const s16 xBase = WB_CENTER_X - 32;
     const s16 yBase = WB_CENTER_Y - 32;
-    for (row = 0; row < 3; row++)
+    for (row = 0; row < CRAFT_ROWS; row++)
     {
-        for (col = 0; col < 3; col++)
+        for (col = 0; col < CRAFT_COLS; col++)
         {
-            i = row * 3 + col;
+            i = row * CRAFT_COLS + col;
             sWorkbenchSpriteIds[i] = CreateSprite(&sWorkbenchTemplates[i], xBase + 32 * col, yBase + 32 * row, 0);
         }
     }
@@ -401,13 +401,13 @@ bool8 CraftMenuUI_HandleDpadInput(void)
 {
     u8 oldPos = sCraftCursorPos;
 
-    if (JOY_NEW(DPAD_UP) && sCraftCursorPos >= 3)
-        sCraftCursorPos -= 3;
-    else if (JOY_NEW(DPAD_DOWN) && sCraftCursorPos < 6)
-        sCraftCursorPos += 3;
-    else if (JOY_NEW(DPAD_LEFT) && sCraftCursorPos % 3 != 0)
+    if (JOY_NEW(DPAD_UP) && sCraftCursorPos >= CRAFT_COLS)
+        sCraftCursorPos -= CRAFT_COLS;
+    else if (JOY_NEW(DPAD_DOWN) && sCraftCursorPos < CRAFT_SLOT_COUNT - CRAFT_COLS)
+        sCraftCursorPos += CRAFT_COLS;
+    else if (JOY_NEW(DPAD_LEFT) && sCraftCursorPos % CRAFT_COLS != 0)
         sCraftCursorPos--;
-    else if (JOY_NEW(DPAD_RIGHT) && sCraftCursorPos % 3 != 2)
+    else if (JOY_NEW(DPAD_RIGHT) && sCraftCursorPos % CRAFT_COLS != CRAFT_COLS - 1)
         sCraftCursorPos++;
 
     return (sCraftCursorPos != oldPos);

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -232,8 +232,8 @@ static void UpdateCraftInfoWindow(void)
 
 static void UpdateItemInfoWindow(void)
 {
-    int row = sCraftCursorPos / CRAFT_COLS;
-    int col = sCraftCursorPos % CRAFT_COLS;
+    int row = CRAFT_SLOT_ROW(sCraftCursorPos);
+    int col = CRAFT_SLOT_COL(sCraftCursorPos);
 
     if (gCraftSlots[row][col].itemId != ITEM_NONE)
     {

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2404,9 +2404,9 @@ static void FinishCraftSelection(u8 taskId)
 {
     s16 *data = gTasks[taskId].data;
 
-    if (gCraftSlots[gCraftActiveSlot / CRAFT_COLS][gCraftActiveSlot % CRAFT_COLS].itemId != ITEM_NONE)
-        AddBagItem(gCraftSlots[gCraftActiveSlot / CRAFT_COLS][gCraftActiveSlot % CRAFT_COLS].itemId,
-                   gCraftSlots[gCraftActiveSlot / CRAFT_COLS][gCraftActiveSlot % CRAFT_COLS].quantity);
+    if (gCraftSlots[CRAFT_SLOT_ROW(gCraftActiveSlot)][CRAFT_SLOT_COL(gCraftActiveSlot)].itemId != ITEM_NONE)
+        AddBagItem(gCraftSlots[CRAFT_SLOT_ROW(gCraftActiveSlot)][CRAFT_SLOT_COL(gCraftActiveSlot)].itemId,
+                   gCraftSlots[CRAFT_SLOT_ROW(gCraftActiveSlot)][CRAFT_SLOT_COL(gCraftActiveSlot)].quantity);
 
     CraftLogic_SetSlot(gCraftActiveSlot, gSpecialVar_ItemId, tItemCount);
     RemoveBagItem(gSpecialVar_ItemId, tItemCount);

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2404,8 +2404,9 @@ static void FinishCraftSelection(u8 taskId)
 {
     s16 *data = gTasks[taskId].data;
 
-    if (gCraftSlots[gCraftActiveSlot].itemId != ITEM_NONE)
-        AddBagItem(gCraftSlots[gCraftActiveSlot].itemId, gCraftSlots[gCraftActiveSlot].quantity);
+    if (gCraftSlots[gCraftActiveSlot / CRAFT_COLS][gCraftActiveSlot % CRAFT_COLS].itemId != ITEM_NONE)
+        AddBagItem(gCraftSlots[gCraftActiveSlot / CRAFT_COLS][gCraftActiveSlot % CRAFT_COLS].itemId,
+                   gCraftSlots[gCraftActiveSlot / CRAFT_COLS][gCraftActiveSlot % CRAFT_COLS].quantity);
 
     CraftLogic_SetSlot(gCraftActiveSlot, gSpecialVar_ItemId, tItemCount);
     RemoveBagItem(gSpecialVar_ItemId, tItemCount);


### PR DESCRIPTION
## Summary
- remove `CraftSlotPtr` helper
- access `gCraftSlots` directly with row/column calculations
- refactor loops to iterate over rows and columns

## Testing
- `make tidy` *(fails: `arm-none-eabi-gcc: command not found`)*
- `make check` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68508d068c48832eb7360627308dbca2