### PR TITLE
Implement crafting action based on recipe shapes

### DIFF
--- a/include/craft_logic.h
+++ b/include/craft_logic.h
@@ -17,12 +17,7 @@ void CraftLogic_InitSlots(void);
 void CraftLogic_SetSlot(u8 slot, u16 itemId, u16 quantity);
 void CraftLogic_SwapSlots(u8 slotA, u8 slotB);
 
-struct CraftRecipe
-{
-    u16 pattern[CRAFT_ROWS][CRAFT_COLS];
-    u16 resultItemId;
-    u16 resultQuantity;
-};
+struct CraftRecipe;
 
 u16 CraftLogic_Craft(const struct CraftRecipe *recipes, u16 recipeCount);
 

--- a/include/craft_logic.h
+++ b/include/craft_logic.h
@@ -17,4 +17,13 @@ void CraftLogic_InitSlots(void);
 void CraftLogic_SetSlot(u8 slot, u16 itemId, u16 quantity);
 void CraftLogic_SwapSlots(u8 slotA, u8 slotB);
 
+struct CraftRecipe
+{
+    u16 pattern[CRAFT_ROWS][CRAFT_COLS];
+    u16 resultItemId;
+    u16 resultQuantity;
+};
+
+u16 CraftLogic_Craft(const struct CraftRecipe *recipes, u16 recipeCount);
+
 #endif // GUARD_CRAFT_LOGIC_H

--- a/include/craft_logic.h
+++ b/include/craft_logic.h
@@ -17,8 +17,8 @@ void CraftLogic_InitSlots(void);
 void CraftLogic_SetSlot(u8 slot, u16 itemId, u16 quantity);
 void CraftLogic_SwapSlots(u8 slotA, u8 slotB);
 
-struct CraftRecipe;
+struct CraftRecipeList;
 
-u16 CraftLogic_Craft(const struct CraftRecipe *recipes, u16 recipeCount);
+u16 CraftLogic_Craft(const struct CraftRecipeList *recipes, u16 recipeCount);
 
 #endif // GUARD_CRAFT_LOGIC_H

--- a/src/craft_logic.c
+++ b/src/craft_logic.c
@@ -36,3 +36,117 @@ void CraftLogic_SwapSlots(u8 slotA, u8 slotB)
     gCraftSlots[CRAFT_SLOT_ROW(slotA)][CRAFT_SLOT_COL(slotA)] = gCraftSlots[CRAFT_SLOT_ROW(slotB)][CRAFT_SLOT_COL(slotB)];
     gCraftSlots[CRAFT_SLOT_ROW(slotB)][CRAFT_SLOT_COL(slotB)] = temp;
 }
+
+static void GetRecipeDimensions(const struct CraftRecipe *recipe, int *rows, int *cols)
+{
+    int r, c;
+    int maxRow = -1;
+    int maxCol = -1;
+
+    for (r = 0; r < CRAFT_ROWS; r++)
+    {
+        for (c = 0; c < CRAFT_COLS; c++)
+        {
+            if (recipe->pattern[r][c] != ITEM_NONE)
+            {
+                if (r > maxRow)
+                    maxRow = r;
+                if (c > maxCol)
+                    maxCol = c;
+            }
+        }
+    }
+
+    *rows = maxRow + 1;
+    *cols = maxCol + 1;
+}
+
+static u16 TryCraftRecipeAt(const struct CraftRecipe *recipe, int baseRow, int baseCol, int patRows, int patCols)
+{
+    int r, c;
+    u16 minQty = 0xFFFF;
+
+    for (r = 0; r < patRows; r++)
+    {
+        for (c = 0; c < patCols; c++)
+        {
+            u16 itemId = recipe->pattern[r][c];
+            if (itemId != ITEM_NONE)
+            {
+                struct ItemSlot *slot = &gCraftSlots[baseRow + r][baseCol + c];
+                if (slot->itemId != itemId || slot->quantity == 0)
+                    return 0;
+                if (slot->quantity < minQty)
+                    minQty = slot->quantity;
+            }
+        }
+    }
+
+    if (minQty == 0 || minQty == 0xFFFF)
+        return 0;
+
+    for (r = 0; r < patRows; r++)
+    {
+        for (c = 0; c < patCols; c++)
+        {
+            if (recipe->pattern[r][c] != ITEM_NONE)
+            {
+                struct ItemSlot *slot = &gCraftSlots[baseRow + r][baseCol + c];
+                slot->quantity -= minQty;
+                if (slot->quantity == 0)
+                    slot->itemId = ITEM_NONE;
+            }
+        }
+    }
+
+    return minQty;
+}
+
+static u16 ApplyRecipe(const struct CraftRecipe *recipe)
+{
+    int patRows, patCols;
+    u16 crafted = 0;
+
+    GetRecipeDimensions(recipe, &patRows, &patCols);
+
+    if (patRows == 0 || patCols == 0)
+        return 0;
+
+    bool8 progress;
+    do
+    {
+        int baseRow, baseCol;
+        progress = FALSE;
+
+        for (baseRow = 0; baseRow <= CRAFT_ROWS - patRows && !progress; baseRow++)
+        {
+            for (baseCol = 0; baseCol <= CRAFT_COLS - patCols && !progress; baseCol++)
+            {
+                u16 sets = TryCraftRecipeAt(recipe, baseRow, baseCol, patRows, patCols);
+                if (sets)
+                {
+                    crafted += sets;
+                    progress = TRUE;
+                }
+            }
+        }
+    } while (progress);
+
+    if (crafted)
+        AddBagItem(recipe->resultItemId, crafted * recipe->resultQuantity);
+
+    return crafted * recipe->resultQuantity;
+}
+
+u16 CraftLogic_Craft(const struct CraftRecipe *recipes, u16 recipeCount)
+{
+    u16 i;
+    for (i = 0; i < recipeCount; i++)
+    {
+        u16 crafted = ApplyRecipe(&recipes[i]);
+        if (crafted)
+            return crafted;
+    }
+
+    return 0;
+}

--- a/src/craft_logic.c
+++ b/src/craft_logic.c
@@ -103,7 +103,7 @@ static u16 TryCraftRecipeAt(const struct CraftRecipe *recipe, int baseRow, int b
     return minQty;
 }
 
-static u16 ApplyRecipe(const struct CraftRecipe *recipe)
+static u16 ApplyRecipe(u16 resultItemId, const struct CraftRecipe *recipe)
 {
     int patRows, patCols;
     u16 crafted = 0;
@@ -134,19 +134,24 @@ static u16 ApplyRecipe(const struct CraftRecipe *recipe)
     } while (progress);
 
     if (crafted)
-        AddBagItem(recipe->resultItemId, crafted * recipe->resultQuantity);
+        AddBagItem(resultItemId, crafted * recipe->resultQuantity);
 
     return crafted * recipe->resultQuantity;
 }
 
-u16 CraftLogic_Craft(const struct CraftRecipe *recipes, u16 recipeCount)
+u16 CraftLogic_Craft(const struct CraftRecipeList *recipes, u16 recipeCount)
 {
-    u16 i;
-    for (i = 0; i < recipeCount; i++)
+    u16 itemId;
+    for (itemId = 0; itemId < recipeCount; itemId++)
     {
-        u16 crafted = ApplyRecipe(&recipes[i]);
-        if (crafted)
-            return crafted;
+        const struct CraftRecipeList *list = &recipes[itemId];
+        u8 r;
+        for (r = 0; r < list->count; r++)
+        {
+            u16 crafted = ApplyRecipe(itemId, &list->recipes[r]);
+            if (crafted)
+                return crafted;
+        }
     }
 
     return 0;

--- a/src/craft_logic.c
+++ b/src/craft_logic.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "constants/items.h"
 #include "craft_logic.h"
+#include "data/crafting_recipes.h"
 
 EWRAM_DATA struct ItemSlot gCraftSlots[CRAFT_ROWS][CRAFT_COLS];
 EWRAM_DATA u8 gCraftActiveSlot = 0;

--- a/src/craft_menu.c
+++ b/src/craft_menu.c
@@ -11,6 +11,7 @@
 #include "event_object_lock.h"
 #include "craft_menu_ui.h"
 #include "craft_logic.h"
+#include "data/crafting_recipes.h"
 #include "item.h"
 #include "item_menu.h"
 #include "strings.h"
@@ -169,6 +170,13 @@ static bool8 HandleCraftMenuInput(void)
         return TRUE;
     }
 #endif
+
+    if (JOY_NEW(START_BUTTON))
+    {
+        PlaySE(SE_SELECT);
+        if (CraftLogic_Craft(gCraftRecipes, gCraftRecipeCount))
+            CraftMenuUI_DrawIcons();
+    }
 
     if (CraftMenuUI_HandleDpadInput())
     {

--- a/src/data/crafting_recipes.h
+++ b/src/data/crafting_recipes.h
@@ -3,26 +3,26 @@
 
 #include "craft_logic.h"
 
-#ifndef ITEM_TUMBLESTONE
-#define ITEM_TUMBLESTONE ITEM_STARDUST
-#endif
+struct CraftRecipe
+{
+    u16 pattern[CRAFT_ROWS][CRAFT_COLS];
+    u16 resultItemId;
+    u16 resultQuantity;
+};
 
-#ifndef ITEM_IRON_CHUNK
-#define ITEM_IRON_CHUNK ITEM_NUGGET
-#endif
-
-static const struct CraftRecipe sPokeballRecipe = {
+static const struct CraftRecipe sRecipe_Antidote =
+{
     .pattern = {
-        { ITEM_TUMBLESTONE, ITEM_IRON_CHUNK, ITEM_NONE },
-        { ITEM_RED_APRICORN, ITEM_NONE, ITEM_NONE },
-        { ITEM_NONE, ITEM_NONE, ITEM_NONE },
+        { ITEM_POTION },
+        { ITEM_PECHA_BERRY },
     },
-    .resultItemId = ITEM_POKE_BALL,
+    .resultItemId = ITEM_ANTIDOTE,
     .resultQuantity = 3,
 };
 
-static const struct CraftRecipe gCraftRecipes[] = {
-    sPokeballRecipe,
+static const struct CraftRecipe gCraftRecipes[] =
+{
+    sRecipe_Antidote,
 };
 
 static const u16 gCraftRecipeCount = ARRAY_COUNT(gCraftRecipes);

--- a/src/data/crafting_recipes.h
+++ b/src/data/crafting_recipes.h
@@ -1,0 +1,30 @@
+#ifndef GUARD_CRAFTING_RECIPES_H
+#define GUARD_CRAFTING_RECIPES_H
+
+#include "craft_logic.h"
+
+#ifndef ITEM_TUMBLESTONE
+#define ITEM_TUMBLESTONE ITEM_STARDUST
+#endif
+
+#ifndef ITEM_IRON_CHUNK
+#define ITEM_IRON_CHUNK ITEM_NUGGET
+#endif
+
+static const struct CraftRecipe sPokeballRecipe = {
+    .pattern = {
+        { ITEM_TUMBLESTONE, ITEM_IRON_CHUNK, ITEM_NONE },
+        { ITEM_RED_APRICORN, ITEM_NONE, ITEM_NONE },
+        { ITEM_NONE, ITEM_NONE, ITEM_NONE },
+    },
+    .resultItemId = ITEM_POKE_BALL,
+    .resultQuantity = 3,
+};
+
+static const struct CraftRecipe gCraftRecipes[] = {
+    sPokeballRecipe,
+};
+
+static const u16 gCraftRecipeCount = ARRAY_COUNT(gCraftRecipes);
+
+#endif // GUARD_CRAFTING_RECIPES_H

--- a/src/data/crafting_recipes.h
+++ b/src/data/crafting_recipes.h
@@ -6,27 +6,47 @@
 struct CraftRecipe
 {
     u16 pattern[CRAFT_ROWS][CRAFT_COLS];
-    u16 resultItemId;
     u16 resultQuantity;
 };
 
-static const struct CraftRecipe gCraftRecipes[] =
+struct CraftRecipeList
+{
+    const struct CraftRecipe *recipes;
+    u8 count;
+};
+
+static const struct CraftRecipe sAntidoteRecipes[] =
 {
     {
         .pattern = {
             { ITEM_POTION },
             { ITEM_PECHA_BERRY },
         },
-        .resultItemId = ITEM_ANTIDOTE,
         .resultQuantity = 3,
     },
+};
+
+static const struct CraftRecipe sSuperPotionRecipes[] =
+{
     {
         .pattern = {
             { ITEM_POTION, ITEM_POTION, ITEM_POTION },
         },
-        .resultItemId = ITEM_SUPER_POTION,
         .resultQuantity = 2,
     },
+    {
+        .pattern = {
+            { ITEM_ORAN_BERRY, ITEM_ORAN_BERRY },
+            { ITEM_FRESH_WATER },
+        },
+        .resultQuantity = 2,
+    },
+};
+
+static const struct CraftRecipeList gCraftRecipes[ITEMS_COUNT] =
+{
+    [ITEM_ANTIDOTE] = { sAntidoteRecipes, ARRAY_COUNT(sAntidoteRecipes) },
+    [ITEM_SUPER_POTION] = { sSuperPotionRecipes, ARRAY_COUNT(sSuperPotionRecipes) },
 };
 
 static const u16 gCraftRecipeCount = ARRAY_COUNT(gCraftRecipes);

--- a/src/data/crafting_recipes.h
+++ b/src/data/crafting_recipes.h
@@ -10,19 +10,23 @@ struct CraftRecipe
     u16 resultQuantity;
 };
 
-static const struct CraftRecipe sRecipe_Antidote =
-{
-    .pattern = {
-        { ITEM_POTION },
-        { ITEM_PECHA_BERRY },
-    },
-    .resultItemId = ITEM_ANTIDOTE,
-    .resultQuantity = 3,
-};
-
 static const struct CraftRecipe gCraftRecipes[] =
 {
-    sRecipe_Antidote,
+    {
+        .pattern = {
+            { ITEM_POTION },
+            { ITEM_PECHA_BERRY },
+        },
+        .resultItemId = ITEM_ANTIDOTE,
+        .resultQuantity = 3,
+    },
+    {
+        .pattern = {
+            { ITEM_POTION, ITEM_POTION, ITEM_POTION },
+        },
+        .resultItemId = ITEM_SUPER_POTION,
+        .resultQuantity = 2,
+    },
 };
 
 static const u16 gCraftRecipeCount = ARRAY_COUNT(gCraftRecipes);

--- a/src/data/crafting_recipes.h
+++ b/src/data/crafting_recipes.h
@@ -15,38 +15,45 @@ struct CraftRecipeList
     u8 count;
 };
 
-static const struct CraftRecipe sAntidoteRecipes[] =
-{
-    {
-        .pattern = {
-            { ITEM_POTION },
-            { ITEM_PECHA_BERRY },
-        },
-        .resultQuantity = 3,
-    },
-};
-
-static const struct CraftRecipe sSuperPotionRecipes[] =
-{
-    {
-        .pattern = {
-            { ITEM_POTION, ITEM_POTION, ITEM_POTION },
-        },
-        .resultQuantity = 2,
-    },
-    {
-        .pattern = {
-            { ITEM_ORAN_BERRY, ITEM_ORAN_BERRY },
-            { ITEM_FRESH_WATER },
-        },
-        .resultQuantity = 2,
-    },
-};
-
 static const struct CraftRecipeList gCraftRecipes[ITEMS_COUNT] =
 {
-    [ITEM_ANTIDOTE] = { sAntidoteRecipes, ARRAY_COUNT(sAntidoteRecipes) },
-    [ITEM_SUPER_POTION] = { sSuperPotionRecipes, ARRAY_COUNT(sSuperPotionRecipes) },
+    [ITEM_ANTIDOTE] =
+    {
+        .recipes = (const struct CraftRecipe[])
+        {
+            {
+                .pattern =
+                {
+                    { ITEM_POTION },
+                    { ITEM_PECHA_BERRY },
+                },
+                .resultQuantity = 3,
+            },
+        },
+        .count = 1,
+    },
+    [ITEM_SUPER_POTION] =
+    {
+        .recipes = (const struct CraftRecipe[])
+        {
+            {
+                .pattern =
+                {
+                    { ITEM_POTION, ITEM_POTION, ITEM_POTION },
+                },
+                .resultQuantity = 2,
+            },
+            {
+                .pattern =
+                {
+                    { ITEM_ORAN_BERRY, ITEM_ORAN_BERRY },
+                    { ITEM_FRESH_WATER },
+                },
+                .resultQuantity = 2,
+            },
+        },
+        .count = 2,
+    },
 };
 
 static const u16 gCraftRecipeCount = ARRAY_COUNT(gCraftRecipes);


### PR DESCRIPTION
## Summary
- add `CraftRecipe` struct and crafting API
- implement crafting logic that checks recipe patterns and consumes items
- add example Poké Ball recipe data
- allow the crafting menu to craft with `START` button

## Testing
- `make -j$(nproc)` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ba9127d0832e9d1b3050675da21b