### PR TITLE
Add dynamic crafting prompt color

### DIFF
--- a/include/craft_logic.h
+++ b/include/craft_logic.h
@@ -20,5 +20,6 @@ void CraftLogic_SwapSlots(u8 slotA, u8 slotB);
 struct CraftRecipeList;
 
 u16 CraftLogic_Craft(const struct CraftRecipeList *recipes, u16 recipeCount);
+bool8 CraftLogic_CanCraft(const struct CraftRecipeList *recipes, u16 recipeCount);
 
 #endif // GUARD_CRAFT_LOGIC_H

--- a/src/craft_logic.c
+++ b/src/craft_logic.c
@@ -156,3 +156,57 @@ u16 CraftLogic_Craft(const struct CraftRecipeList *recipes, u16 recipeCount)
 
     return 0;
 }
+
+static bool8 CanCraftRecipeAt(const struct CraftRecipe *recipe, int baseRow, int baseCol, int patRows, int patCols)
+{
+    int r, c;
+
+    for (r = 0; r < patRows; r++)
+    {
+        for (c = 0; c < patCols; c++)
+        {
+            u16 itemId = recipe->pattern[r][c];
+            if (itemId != ITEM_NONE)
+            {
+                struct ItemSlot *slot = &gCraftSlots[baseRow + r][baseCol + c];
+                if (slot->itemId != itemId || slot->quantity == 0)
+                    return FALSE;
+            }
+        }
+    }
+
+    return TRUE;
+}
+
+bool8 CraftLogic_CanCraft(const struct CraftRecipeList *recipes, u16 recipeCount)
+{
+    u16 itemId;
+
+    for (itemId = 0; itemId < recipeCount; itemId++)
+    {
+        const struct CraftRecipeList *list = &recipes[itemId];
+        u8 r;
+        for (r = 0; r < list->count; r++)
+        {
+            const struct CraftRecipe *recipe = &list->recipes[r];
+            int patRows, patCols;
+
+            GetRecipeDimensions(recipe, &patRows, &patCols);
+
+            if (patRows == 0 || patCols == 0)
+                continue;
+
+            int baseRow, baseCol;
+            for (baseRow = 0; baseRow <= CRAFT_ROWS - patRows; baseRow++)
+            {
+                for (baseCol = 0; baseCol <= CRAFT_COLS - patCols; baseCol++)
+                {
+                    if (CanCraftRecipeAt(recipe, baseRow, baseCol, patRows, patCols))
+                        return TRUE;
+                }
+            }
+        }
+    }
+
+    return FALSE;
+}

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -22,6 +22,7 @@
 #include "constants/songs.h"
 #include "constants/items.h"
 #include "craft_logic.h"
+#include "data/crafting_recipes.h"
 #include "craft_menu_ui.h"
 
 #define TAG_WB_TOPLEFT     0x4001
@@ -225,7 +226,8 @@ static void UpdateCraftInfoWindow(void)
     AddTextPrinterParameterized3(sCraftInfoWindowId, FONT_NORMAL, 2, 7, sInputTextColor, 0, sText_CraftingUi_AButton);
     AddTextPrinterParameterized3(sCraftInfoWindowId, FONT_SMALL, 13, 2, sInputTextColor, 0, sText_CraftingUi_AddItem);
     AddTextPrinterParameterized3(sCraftInfoWindowId, FONT_NORMAL, 45, 7, sInputTextColor, 0, sText_CraftingUi_BButtonExit);
-    AddTextPrinterParameterized3(sCraftInfoWindowId, FONT_NORMAL, 85, 7, sHintTextColor, 0, sText_CraftingUi_StartButtonCraft);
+    const u8 *startColor = CraftLogic_CanCraft(gCraftRecipes, gCraftRecipeCount) ? sHintTextColor : sInputTextColor;
+    AddTextPrinterParameterized3(sCraftInfoWindowId, FONT_NORMAL, 85, 7, startColor, 0, sText_CraftingUi_StartButtonCraft);
     AddTextPrinterParameterized3(sCraftInfoWindowId, FONT_NORMAL, 148, 7, sInputTextColor, 0, sText_CraftingUi_SelectButton);
     AddTextPrinterParameterized3(sCraftInfoWindowId, FONT_SMALL, 175, 2, sInputTextColor, 0, sText_CraftingUi_RecipeBook);
 }
@@ -378,6 +380,8 @@ void CraftMenuUI_DrawIcons(void)
     }
 
     UpdateItemInfoWindow();
+    UpdateCraftInfoWindow();
+    CopyWindowToVram(sCraftInfoWindowId, COPYWIN_FULL);
 }
 
 void CraftMenuUI_UpdateGrid(void)


### PR DESCRIPTION
## Summary
- add `CraftLogic_CanCraft` helper to check recipes
- update craft prompt color based on craftability
- refresh info window when icons change

## Testing
- `make -j$(nproc)` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d506745c832ebe2c299aea1e150d