### PR TITLE
Add flag-based craft recipe unlocking

### DIFF
--- a/src/craft_logic.c
+++ b/src/craft_logic.c
@@ -2,6 +2,7 @@
 #include "constants/items.h"
 #include "craft_logic.h"
 #include "data/crafting_recipes.h"
+#include "event_data.h"
 
 EWRAM_DATA struct ItemSlot gCraftSlots[CRAFT_ROWS][CRAFT_COLS];
 EWRAM_DATA u8 gCraftActiveSlot = 0;
@@ -173,6 +174,8 @@ const struct CraftRecipe *CraftLogic_GetMatchingRecipe(const struct CraftRecipeL
         for (r = 0; r < list->count; r++)
         {
             const struct CraftRecipe *recipe = &list->recipes[r];
+            if (recipe->unlockFlag != 0 && !FlagGet(recipe->unlockFlag))
+                continue;
             int patRows, patCols;
 
             GetRecipeDimensions(recipe, &patRows, &patCols);
@@ -204,6 +207,9 @@ u16 CraftLogic_GetCraftableQuantity(const struct CraftRecipe *recipe)
     struct ItemSlot temp[CRAFT_ROWS][CRAFT_COLS];
     int patRows, patCols;
     u16 crafted = 0;
+
+    if (recipe->unlockFlag != 0 && !FlagGet(recipe->unlockFlag))
+        return 0;
 
     memcpy(temp, gCraftSlots, sizeof(temp));
     GetRecipeDimensions(recipe, &patRows, &patCols);

--- a/src/data/crafting_recipes.h
+++ b/src/data/crafting_recipes.h
@@ -2,11 +2,13 @@
 #define GUARD_CRAFTING_RECIPES_H
 
 #include "craft_logic.h"
+#include "constants/flags.h"
 
 struct CraftRecipe
 {
     u16 pattern[CRAFT_ROWS][CRAFT_COLS];
     u16 resultQuantity;
+    u16 unlockFlag; // FLAG_NONE for always unlocked
 };
 
 struct CraftRecipeList
@@ -28,6 +30,7 @@ static const struct CraftRecipeList gCraftRecipes[ITEMS_COUNT] =
                     { ITEM_PECHA_BERRY },
                 },
                 .resultQuantity = 3,
+                .unlockFlag = 0,
             },
         },
         .count = 1,
@@ -42,6 +45,7 @@ static const struct CraftRecipeList gCraftRecipes[ITEMS_COUNT] =
                     { ITEM_POTION, ITEM_POTION, ITEM_POTION },
                 },
                 .resultQuantity = 2,
+                .unlockFlag = FLAG_ITEM_ROUTE_102_POTION,
             },
             {
                 .pattern =
@@ -50,6 +54,7 @@ static const struct CraftRecipeList gCraftRecipes[ITEMS_COUNT] =
                     { ITEM_FRESH_WATER },
                 },
                 .resultQuantity = 2,
+                .unlockFlag = 0,
             },
         },
         .count = 2,


### PR DESCRIPTION
## Summary
- support locking crafting recipes behind game flags
- gate the Super Potion recipe that uses Potions behind `FLAG_ITEM_ROUTE_102_POTION`

## Testing
- `make -j1` *(fails: `arm-none-eabi-gcc: command not found`)*
- `make check` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851b3106264832e99e42b092f408a33