### PR TITLE
Organize crafting system source

### DIFF
--- a/include/craft_logic.h
+++ b/include/craft_logic.h
@@ -10,8 +10,16 @@
 #define CRAFT_SLOT_ROW(slot) ((slot) / CRAFT_COLS)
 #define CRAFT_SLOT_COL(slot) ((slot) % CRAFT_COLS)
 
-extern struct ItemSlot gCraftSlots[CRAFT_ROWS][CRAFT_COLS];
-extern u8 gCraftActiveSlot;
+struct CraftMenuState
+{
+    struct ItemSlot slots[CRAFT_ROWS][CRAFT_COLS];
+    u8 activeSlot;
+};
+
+extern struct CraftMenuState gCraftState;
+
+#define gCraftSlots      (gCraftState.slots)
+#define gCraftActiveSlot (gCraftState.activeSlot)
 
 void CraftLogic_InitSlots(void);
 void CraftLogic_SetSlot(u8 slot, u16 itemId, u16 quantity);

--- a/src/craft_logic.c
+++ b/src/craft_logic.c
@@ -4,8 +4,15 @@
 #include "data/crafting_recipes.h"
 #include "event_data.h"
 
-EWRAM_DATA struct ItemSlot gCraftSlots[CRAFT_ROWS][CRAFT_COLS];
-EWRAM_DATA u8 gCraftActiveSlot = 0;
+//---------------------------------------------------------------------------
+// Crafting state
+//---------------------------------------------------------------------------
+
+EWRAM_DATA struct CraftMenuState gCraftState = {0};
+
+//---------------------------------------------------------------------------
+// Initialization and slot management
+//---------------------------------------------------------------------------
 
 void CraftLogic_InitSlots(void)
 {
@@ -38,6 +45,10 @@ void CraftLogic_SwapSlots(u8 slotA, u8 slotB)
     gCraftSlots[CRAFT_SLOT_ROW(slotA)][CRAFT_SLOT_COL(slotA)] = gCraftSlots[CRAFT_SLOT_ROW(slotB)][CRAFT_SLOT_COL(slotB)];
     gCraftSlots[CRAFT_SLOT_ROW(slotB)][CRAFT_SLOT_COL(slotB)] = temp;
 }
+
+//---------------------------------------------------------------------------
+// Recipe utilities
+//---------------------------------------------------------------------------
 
 static void GetRecipeDimensions(const struct CraftRecipe *recipe, int *rows, int *cols)
 {
@@ -162,6 +173,10 @@ static u16 ApplyRecipe(u16 resultItemId, const struct CraftRecipe *recipe)
 
     return crafted * recipe->resultQuantity;
 }
+
+//---------------------------------------------------------------------------
+// Public crafting API
+//---------------------------------------------------------------------------
 
 const struct CraftRecipe *CraftLogic_GetMatchingRecipe(const struct CraftRecipeList *recipes, u16 recipeCount, u16 *resultItemId)
 {

--- a/src/craft_menu.c
+++ b/src/craft_menu.c
@@ -49,6 +49,10 @@ static void CraftYes(u8 taskId);
 static void CraftNo(u8 taskId);
 void CB2_ReturnToCraftMenu(void);
 
+//---------------------------------------------------------------------------
+// Entry points
+//---------------------------------------------------------------------------
+
 void StartCraftMenu(void)
 {
     PlayerFreeze();
@@ -70,6 +74,10 @@ static void Task_RunCraftMenu(u8 taskId)
     if (gMenuCallback && gMenuCallback() == TRUE)
         DestroyTask(taskId);
 }
+
+//---------------------------------------------------------------------------
+// Menu workflow and state
+//---------------------------------------------------------------------------
 
 static bool8 sKeepSlots = FALSE;
 
@@ -97,6 +105,18 @@ void CB2_ReturnToCraftMenu(void)
 {
     gFieldCallback = CraftMenu_ReshowAfterBagMenu;
     SetMainCallback2(CB2_ReturnToField);
+}
+void CB2_OpenCraftMenu(void)
+{
+    StartCraftMenu();
+    SetMainCallback2(CB2_Overworld);
+}
+
+static void CraftMenu_ReshowAfterBagMenu(void)
+{
+    sKeepSlots = TRUE;
+    StartCraftMenu();
+    FadeInFromBlack();
 }
 
 static void Task_WaitFadeAndOpenBag(u8 taskId)
@@ -127,6 +147,10 @@ static void OpenBagFromCraftMenu(void)
     FadeScreen(FADE_TO_BLACK, 0);
     CreateTask(Task_WaitFadeAndOpenBag, 0);
 }
+
+//---------------------------------------------------------------------------
+// Input handlers
+//---------------------------------------------------------------------------
 
 static bool8 HandleCraftMenuInput(void)
 {
@@ -273,6 +297,10 @@ static void PackUpNo(u8 taskId)
     DestroyTask(taskId);
 }
 
+//---------------------------------------------------------------------------
+// Slot and swap actions
+//---------------------------------------------------------------------------
+
 static void Action_SwapItem(void)
 {
     OpenBagFromCraftMenu();
@@ -373,6 +401,10 @@ static u16 sAdjustOldQty;
 static u16 sAdjustMaxQty;
 static u16 sAdjustItemId;
 
+//---------------------------------------------------------------------------
+// Quantity adjustment tasks
+//---------------------------------------------------------------------------
+
 static void Task_AdjustQuantity_Start(u8 taskId)
 {
     int row = CRAFT_SLOT_ROW(CraftMenuUI_GetCursorPos());
@@ -432,6 +464,10 @@ static const struct YesNoFuncTable sPackUpYesNoFuncs = {
     .noFunc = PackUpNo,
 };
 
+//---------------------------------------------------------------------------
+// Pack-up and confirmation tasks
+//---------------------------------------------------------------------------
+
 static void Task_ShowPackUpYesNo(u8 taskId)
 {
     CraftMenuUI_ShowPackUpYesNo();
@@ -443,18 +479,6 @@ static void Task_PackUpAsk(u8 taskId)
     CraftMenuUI_DisplayPackUpMessage(taskId, Task_ShowPackUpYesNo);
 }
 
-void CB2_OpenCraftMenu(void)
-{
-    StartCraftMenu();
-    SetMainCallback2(CB2_Overworld);
-}
-
-static void CraftMenu_ReshowAfterBagMenu(void)
-{
-    sKeepSlots = TRUE;
-    StartCraftMenu();
-    FadeInFromBlack();
-}
 
 static void Task_WaitForCraftMessageAck(u8 taskId)
 {
@@ -466,6 +490,10 @@ static void Task_WaitForCraftMessageAck(u8 taskId)
         DestroyTask(taskId);
     }
 }
+
+//---------------------------------------------------------------------------
+// Crafting confirmation flow
+//---------------------------------------------------------------------------
 
 static void Task_NoCraftItems(u8 taskId)
 {

--- a/src/craft_menu_ui.c
+++ b/src/craft_menu_ui.c
@@ -177,6 +177,10 @@ static const struct WindowTemplate sCraftWindowTemplates[NUM_CRAFT_WINDOWS] =
     }
 };
 
+//---------------------------------------------------------------------------
+// Window setup and teardown
+//---------------------------------------------------------------------------
+
 static const struct CompressedSpriteSheet sWorkbenchSheets[] =
 {
     { gCraftWorkbench_TopLeft_Gfx,  0x400, TAG_WB_TOPLEFT },
@@ -315,6 +319,10 @@ static void UpdateItemInfoWindow(void)
         ClearStdWindowAndFrameToTransparent(sCraftItemInfoWindowId, TRUE);
     }
 }
+
+//---------------------------------------------------------------------------
+// Cursor and grid updates
+//---------------------------------------------------------------------------
 
 
 static void CreateWorkbenchSprite(void)
@@ -536,6 +544,10 @@ void CraftMenuUI_SetCursorPos(u8 pos)
     CraftMenuUI_UpdateGrid();
 }
 
+//---------------------------------------------------------------------------
+// Action menu and quantity helpers
+//---------------------------------------------------------------------------
+
 void CraftMenuUI_ShowActionMenu(void)
 {
     HideInfoWindow();
@@ -623,6 +635,10 @@ void CraftMenuUI_PrintInfo(const u8 *text, u8 x, u8 y)
     AddTextPrinterParameterized3(sCraftInfoWindowId, FONT_NORMAL, x, y, sInputTextColor, 0, text);
     CopyWindowToVram(sCraftInfoWindowId, COPYWIN_FULL);
 }
+
+//---------------------------------------------------------------------------
+// Message boxes and confirmation prompts
+//---------------------------------------------------------------------------
 
 void CraftMenuUI_DisplayMessage(u8 taskId, const u8 *text, TaskFunc nextTask)
 {


### PR DESCRIPTION
## Summary
- centralize crafting state in `CraftMenuState` struct and macros
- add section comments in `craft_logic.c`
- group logic in `craft_menu.c`
- split `craft_menu_ui.c` into clear sections
- reorder entry functions in `craft_menu.c`

## Testing
- `make -j4` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851bfd6d980832eb77fcd78bab6d465